### PR TITLE
Add interactive scripts and styles for Seaside Landscaping site

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,14 +1,169 @@
-// Naive client-side partials loader (works on static hosting)
-async function loadPartial(id, url){
-  try{
+// Main client-side script for Seaside Landscaping
+// Handles partial loading, UI interactions, gallery, and contact form
+
+const startTime = Date.now();
+
+async function loadPartial(id, url) {
+  const container = document.getElementById(id);
+  if (!container) return;
+  try {
     const res = await fetch(url);
-    if(!res.ok) throw new Error(`Failed to fetch ${url}`);
-    document.getElementById(id).innerHTML = await res.text();
-  }catch(e){
+    if (!res.ok) throw new Error(`Failed to fetch ${url}`);
+    container.innerHTML = await res.text();
+    return container;
+  } catch (e) {
     console.warn(e);
   }
 }
-document.addEventListener('DOMContentLoaded', () => {
-  loadPartial('site-header','/partials/header.html');
-  loadPartial('site-footer','/partials/footer.html');
-});
+
+function initHeader() {
+  const header = document.querySelector('.site-header');
+  if (!header) return;
+
+  const toggle = header.querySelector('.menu-toggle');
+  const navList = header.querySelector('.nav-list');
+
+  toggle.addEventListener('click', () => {
+    const open = navList.classList.toggle('open');
+    toggle.setAttribute('aria-expanded', open);
+  });
+
+  window.addEventListener('scroll', () => {
+    header.classList.toggle('scrolled', window.scrollY > 10);
+  });
+}
+
+function initFooter() {
+  const year = document.getElementById('current-year');
+  if (year) year.textContent = new Date().getFullYear();
+}
+
+function observeSections() {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+  const observer = new IntersectionObserver(
+    entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.1 }
+  );
+  document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
+}
+
+function initGallery() {
+  const dataEl = document.getElementById('project-data');
+  const gallery = document.getElementById('project-gallery');
+  const modal = document.getElementById('project-modal');
+  if (!dataEl || !gallery || !modal) return;
+
+  const projects = JSON.parse(dataEl.textContent);
+  const buttons = document.querySelectorAll('.filter-button');
+  const items = gallery.querySelectorAll('.gallery-item');
+
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const filter = btn.dataset.filter;
+      buttons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      items.forEach(item => {
+        const show = filter === 'all' || item.dataset.category === filter;
+        item.style.display = show ? '' : 'none';
+      });
+    });
+  });
+
+  const closeModal = () => modal.classList.remove('open');
+  const modalClose = modal.querySelector('.modal-close');
+  const beforeAfterBtn = modal.querySelector('.before-after-toggle');
+  const beforeImg = modal.querySelector('.before-image');
+  const afterImg = modal.querySelector('.current-image');
+
+  function openModal(id) {
+    const project = projects.find(p => p.id === id);
+    if (!project) return;
+    modal.querySelector('#modal-title').textContent = project.title;
+    modal.querySelector('.modal-subtitle').textContent = project.subtitle;
+    modal.querySelector('.modal-suburb').textContent = project.suburb;
+    modal.querySelector('.modal-scope').textContent = project.scope;
+    modal.querySelector('.modal-materials').textContent = project.materials;
+    modal.querySelector('.modal-description').textContent = project.description;
+    afterImg.src = project.afterImage;
+    afterImg.alt = `After image of ${project.title}`;
+    beforeImg.src = project.beforeImage;
+    beforeImg.alt = `Before image of ${project.title}`;
+    beforeImg.style.display = 'none';
+    afterImg.style.display = 'block';
+    modal.classList.add('open');
+  }
+
+  items.forEach(item => {
+    item.addEventListener('click', () => {
+      openModal(parseInt(item.dataset.projectId, 10));
+    });
+  });
+
+  beforeAfterBtn.addEventListener('click', () => {
+    const showBefore = beforeImg.style.display === 'none';
+    beforeImg.style.display = showBefore ? 'block' : 'none';
+    afterImg.style.display = showBefore ? 'none' : 'block';
+  });
+
+  modalClose.addEventListener('click', closeModal);
+  modal.addEventListener('click', e => {
+    if (e.target === modal) closeModal();
+  });
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') closeModal();
+  });
+}
+
+function initContactForm() {
+  const form = document.getElementById('contactForm');
+  if (!form) return;
+  const timeField = document.getElementById('time-on-page');
+  const messages = document.getElementById('form-messages');
+  const submitBtn = document.getElementById('submit-button');
+
+  form.addEventListener('submit', async e => {
+    if (!form.checkValidity()) return;
+    e.preventDefault();
+    if (form.dataset.submitting) return;
+    form.dataset.submitting = 'true';
+    submitBtn.disabled = true;
+    timeField.value = Math.round((Date.now() - startTime) / 1000);
+    try {
+      const res = await fetch(form.action, {
+        method: 'POST',
+        body: new FormData(form),
+        headers: { Accept: 'application/json' }
+      });
+      if (res.ok) {
+        messages.textContent = "Thanks! We'll be in touch soon.";
+        form.reset();
+      } else {
+        messages.textContent = 'Sorry, there was a problem. Please try again.';
+      }
+    } catch (err) {
+      messages.textContent = 'Network error. Please try again.';
+    }
+    submitBtn.disabled = false;
+    form.dataset.submitting = '';
+  });
+}
+
+async function init() {
+  await loadPartial('header-placeholder', 'partials/header.html');
+  await loadPartial('footer-placeholder', 'partials/footer.html');
+  initHeader();
+  initFooter();
+  observeSections();
+  initGallery();
+  initContactForm();
+}
+
+document.addEventListener('DOMContentLoaded', init);
+

--- a/styles.css
+++ b/styles.css
@@ -1,115 +1,162 @@
 /*
-    Seaside Landscaping - Hand-Coded Styles
-    Author: Your Name/AI Assistant
-    Date: October 2023
-
-    Brand Palette:
-    PRIMARY: #92b8bd (seafoam/teal)
-    ACCENT: #445d48 (deep, earthy green)
-    CANVAS: #fff7eb (warm off-white)
-    Neutrals: charcoal #2b2b2b, light stone #f4efe7
+  Seaside Landscaping - Hand-Coded Styles
+  Palette:
+    Primary: #92b8bd
+    Accent:  #445d48
+    Canvas:  #fff7eb
+    Charcoal:#2b2b2b
+    Light Stone: #f4efe7
 */
 
-/* --- 0. Base & Reset --- */
-*, *::before, *::after {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
+/* --- Base Reset --- */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
+
+:root{
+  --color-primary:#92b8bd;
+  --color-accent:#445d48;
+  --color-canvas:#fff7eb;
+  --color-charcoal:#2b2b2b;
+  --color-light-stone:#f4efe7;
+  --font-sans:'Inter',sans-serif;
+  --font-serif:'Cormorant Garamond',serif;
+  --spacing-xs:.5rem;
+  --spacing-sm:1rem;
+  --spacing-md:1.5rem;
+  --spacing-lg:2rem;
+  --spacing-xl:3rem;
+  --spacing-xxl:4rem;
+  --section-padding:5rem;
+  --container-max:1200px;
+  --radius-soft:12px;
+  --shadow-soft:0 4px 10px rgba(0,0,0,.08);
+  --shadow-hover:0 8px 20px rgba(0,0,0,.15);
 }
 
-:root {
-    /* Colors */
-    --color-primary: #92b8bd;
-    --color-accent: #445d48;
-    --color-canvas: #fff7eb;
-    --color-charcoal: #2b2b2b;
-    --color-light-stone: #f4efe7;
+html{font-size:16px;scroll-behavior:smooth;}
+body{
+  font-family:var(--font-sans);
+  line-height:1.6;
+  color:var(--color-charcoal);
+  background:var(--color-canvas);
+  min-height:100vh;
+  display:flex;
+  flex-direction:column;
+  -webkit-font-smoothing:antialiased;
+  -moz-osx-font-smoothing:grayscale;
+}
+main{flex:1;}
+img,video,svg{max-width:100%;height:auto;display:block;}
+a{color:var(--color-accent);text-decoration:none;transition:color .3s ease;}
+a:hover,a:focus{color:var(--color-primary);text-decoration:underline;outline:none;}
+button{cursor:pointer;font-family:var(--font-sans);border:none;background:none;color:inherit;font-size:inherit;}
 
-    /* Typography */
-    --font-sans: 'Inter', sans-serif;
-    --font-serif: 'Cormorant Garamond', serif;
+h1,h2,h3,h4,h5,h6{font-family:var(--font-sans);line-height:1.2;margin-bottom:var(--spacing-md);color:var(--color-accent);}
+.heading-serif{font-family:var(--font-serif);font-weight:600;}
+h1{font-size:2.8rem;}h2{font-size:2.2rem;}h3{font-size:1.8rem;}h4{font-size:1.4rem;}
+p{margin-bottom:var(--spacing-sm);}
 
-    /* Spacing */
-    --spacing-xs: 0.5rem;
-    --spacing-sm: 1rem;
-    --spacing-md: 1.5rem;
-    --spacing-lg: 2rem;
-    --spacing-xl: 3rem;
-    --spacing-xxl: 4rem;
-    --section-padding: 5rem; /* 80px */
-    --container-max-width: 1200px;
-    --border-radius-soft: 12px;
-    --shadow-soft: 0 4px 10px rgba(0, 0, 0, 0.08);
-    --shadow-hover: 0 8px 20px rgba(0, 0, 0, 0.15);
+/* --- Layout Helpers --- */
+.container{max-width:var(--container-max);margin:0 auto;padding:0 var(--spacing-md);}
+.container-narrow{max-width:700px;margin:0 auto;}
+.text-center{text-align:center;}
+.section-padded{padding:var(--section-padding) 0;}
+.section-canvas-bg{background:var(--color-canvas);}
+.section-accent-bg{background:var(--color-light-stone);}
+
+.grid-4-cols{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:var(--spacing-lg);}
+.grid-2-cols{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:var(--spacing-xl);align-items:center;}
+.grid-2-cols-reverse{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:var(--spacing-xl);align-items:center;}
+.grid-2-cols-reverse>div:first-child{order:2;}
+
+/* --- Buttons --- */
+.button{display:inline-block;padding:var(--spacing-sm) var(--spacing-lg);border-radius:50px;font-weight:600;text-align:center;transition:background .3s,box-shadow .3s;}
+.button-primary{background:var(--color-primary);color:var(--color-accent);}
+.button-primary:hover,.button-primary:focus{box-shadow:var(--shadow-hover);}
+.button-secondary{border:2px solid var(--color-primary);color:var(--color-accent);padding:calc(var(--spacing-sm)-2px) calc(var(--spacing-lg)-2px);}
+.button-secondary:hover,.button-secondary:focus{background:var(--color-primary);color:var(--color-accent);}
+.button-large{padding:var(--spacing-md) var(--spacing-xl);}
+.button-small{padding:var(--spacing-xs) var(--spacing-md);font-size:.875rem;}
+
+/* --- Header --- */
+.site-header{position:sticky;top:0;z-index:1000;background:var(--color-canvas);box-shadow:0 2px 4px rgba(0,0,0,.05);transition:box-shadow .3s,background .3s;}
+.site-header.scrolled{box-shadow:0 4px 12px rgba(0,0,0,.1);background:var(--color-light-stone);}
+.header-inner{display:flex;align-items:center;justify-content:space-between;padding:var(--spacing-sm) 0;}
+.logo-link{display:flex;align-items:center;gap:var(--spacing-sm);color:var(--color-accent);}
+.site-name{font-weight:600;}
+.main-nav .menu-toggle{display:none;border-radius:var(--radius-soft);padding:var(--spacing-xs);}
+.burger-icon{width:24px;height:2px;background:var(--color-accent);position:relative;display:block;}
+.burger-icon::before,.burger-icon::after{content:"";position:absolute;left:0;width:24px;height:2px;background:var(--color-accent);}
+.burger-icon::before{top:-6px;}.burger-icon::after{top:6px;}
+.nav-list{list-style:none;display:flex;gap:var(--spacing-lg);align-items:center;}
+.nav-list.open{display:block;}
+@media(max-width:768px){
+  .main-nav .menu-toggle{display:block;}
+  .nav-list{display:none;flex-direction:column;background:var(--color-canvas);position:absolute;top:100%;right:0;padding:var(--spacing-md);box-shadow:var(--shadow-soft);border-radius:var(--radius-soft);}
+  .nav-list li{margin-bottom:var(--spacing-sm);}
+  .nav-list li:last-child{margin-bottom:0;}
 }
 
-html {
-    scroll-behavior: smooth;
-    font-size: 16px;
+/* --- Hero --- */
+.hero-section{position:relative;min-height:70vh;display:flex;align-items:center;justify-content:center;overflow:hidden;}
+.hero-background{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;filter:brightness(.7);}
+.hero-content{position:relative;z-index:2;text-align:center;color:var(--color-canvas);padding:0 var(--spacing-md);}
+.text-shadow{text-shadow:0 2px 4px rgba(0,0,0,.4);}
+.hero-ctas{margin-top:var(--spacing-lg);display:flex;gap:var(--spacing-md);justify-content:center;flex-wrap:wrap;}
+
+.hero-subpage{background:var(--color-primary);color:var(--color-accent);padding:6rem 0 4rem;}
+
+/* --- Cards & Services --- */
+.card{background:var(--color-canvas);border:1px solid var(--color-light-stone);border-radius:var(--radius-soft);padding:var(--spacing-lg);box-shadow:var(--shadow-soft);transition:box-shadow .3s,transform .3s;}
+.card:hover{box-shadow:var(--shadow-hover);transform:translateY(-4px);}
+.service-cards .card-icon{margin-bottom:var(--spacing-sm);}
+.learn-more{font-size:.9rem;color:var(--color-accent);}
+
+.value-props .value-item{text-align:center;padding:var(--spacing-md);}
+.value-icon{margin:0 auto var(--spacing-sm);}
+
+/* --- Gallery --- */
+.filters{display:flex;gap:var(--spacing-sm);justify-content:center;margin-bottom:var(--spacing-lg);flex-wrap:wrap;}
+.filter-button{padding:var(--spacing-xs) var(--spacing-md);border-radius:50px;border:1px solid var(--color-primary);background:var(--color-canvas);}
+.filter-button.active,.filter-button:hover{background:var(--color-primary);color:var(--color-accent);}
+
+.project-gallery{display:grid;grid-template-columns:repeat(auto-fill,minmax(250px,1fr));gap:var(--spacing-md);}
+.gallery-item{position:relative;cursor:pointer;overflow:hidden;border-radius:var(--radius-soft);box-shadow:var(--shadow-soft);}
+.gallery-item-overlay{position:absolute;inset:0;background:rgba(68,93,72,.8);color:var(--color-canvas);display:flex;flex-direction:column;justify-content:flex-end;padding:var(--spacing-sm);opacity:0;transition:opacity .3s;}
+.gallery-item:hover .gallery-item-overlay{opacity:1;}
+
+/* --- Modal --- */
+.modal{position:fixed;inset:0;background:rgba(0,0,0,.7);display:none;align-items:center;justify-content:center;padding:var(--spacing-md);}
+.modal.open{display:flex;}
+.modal-content{background:var(--color-canvas);color:var(--color-charcoal);max-width:800px;width:100%;border-radius:var(--radius-soft);padding:var(--spacing-lg);position:relative;max-height:90vh;overflow:auto;}
+.modal-close{position:absolute;top:var(--spacing-sm);right:var(--spacing-sm);font-size:1.5rem;line-height:1;color:var(--color-accent);}
+.modal-image-wrapper{position:relative;margin-bottom:var(--spacing-md);}
+.modal-image{width:100%;border-radius:var(--radius-soft);}
+.before-image{display:none;position:absolute;top:0;left:0;}
+.before-after-toggle{margin-top:var(--spacing-sm);display:inline-block;}
+
+/* --- Testimonials --- */
+.testimonial-slider{display:grid;gap:var(--spacing-lg);}
+.testimonial-item{background:var(--color-canvas);padding:var(--spacing-lg);border-radius:var(--radius-soft);box-shadow:var(--shadow-soft);}
+.quote{font-style:italic;margin-bottom:var(--spacing-sm);}
+.client-info{font-weight:600;}
+
+/* --- Footer --- */
+.site-footer{background:var(--color-accent);color:var(--color-canvas);padding:var(--spacing-xl) 0;margin-top:var(--spacing-xl);}
+.footer-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:var(--spacing-xl);}
+.logo-link-footer{display:flex;align-items:center;gap:var(--spacing-sm);color:var(--color-canvas);}
+.footer-links ul,.footer-legal ul{list-style:none;padding:0;}
+.footer-links a,.footer-legal a{color:var(--color-canvas);}
+.footer-links a:hover,.footer-legal a:hover{text-decoration:underline;}
+.social-links a{margin-right:var(--spacing-sm);color:var(--color-canvas);}
+.copyright{margin-top:var(--spacing-sm);font-size:.875rem;}
+
+/* --- Utility & Effects --- */
+.fade-in{opacity:0;transform:translateY(20px);transition:opacity .6s ease,transform .6s ease;}
+.fade-in.visible{opacity:1;transform:none;}
+.section-sub-intro{color:var(--color-accent);margin-bottom:var(--spacing-lg);}
+.divider{display:flex;justify-content:center;margin:var(--spacing-xl) 0;}
+
+@media(prefers-reduced-motion:reduce){
+  *{transition:none!important;animation:none!important;}
 }
 
-body {
-    font-family: var(--font-sans);
-    line-height: 1.6;
-    color: var(--color-charcoal);
-    background-color: var(--color-canvas);
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    text-rendering: optimizeLegibility;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-}
-
-main {
-    flex-grow: 1;
-}
-
-img, video, svg {
-    max-width: 100%;
-    height: auto;
-    display: block;
-}
-
-a {
-    color: var(--color-accent);
-    text-decoration: none;
-    transition: color 0.3s ease;
-}
-
-a:hover, a:focus {
-    color: var(--color-primary);
-    text-decoration: underline;
-    outline: none;
-}
-
-button {
-    cursor: pointer;
-    font-family: var(--font-sans);
-    border: none;
-    background: none;
-    padding: 0;
-    color: inherit;
-    font-size: inherit;
-}
-
-h1, h2, h3, h4, h5, h6 {
-    font-family: var(--font-sans); /* Default to sans */
-    line-height: 1.2;
-    margin-bottom: var(--spacing-md);
-    color: var(--color-accent);
-}
-
-.heading-serif {
-    font-family: var(--font-serif);
-    font-weight: 600;
-}
-
-h1 { font-size: 2.8rem; } /* 44.8px */
-h2 { font-size: 2.2rem; } /* 35.2px */
-h3 { font-size: 1.8rem; } /* 28.8px */
-h4 { font-size: 1.4rem; } /* 22.4px */
-
-p {
-    margin-bottom: var(--spacing-sm);
-}


### PR DESCRIPTION
## Summary
- Load header and footer partials on each page
- Add sticky header, mobile menu, fade-in sections, and project gallery modal
- Style pages with branded palette, grids, buttons, gallery and footer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8e5f4ecc832aacc0c4189ca1fb35